### PR TITLE
update log.retention.bytes

### DIFF
--- a/kafka-ansible/roles/kafka/templates/server.properties.j2
+++ b/kafka-ansible/roles/kafka/templates/server.properties.j2
@@ -113,7 +113,7 @@ log.retention.hours=120
 
 # A size-based retention policy for logs. Segments are pruned from the log unless the remaining
 # segments drop below log.retention.bytes. Functions independently of log.retention.hours.
-log.retention.bytes=1073741824
+log.retention.bytes=107374182400
 
 # The maximum size of a log segment file. When this size is reached a new log segment will be created.
 log.segment.bytes=1073741824


### PR DESCRIPTION
the old value is too small, if the producer is quick than consumer, the data maybe deleted.